### PR TITLE
Include access token when calling /me - it is required.

### DIFF
--- a/mixcloud/__init__.py
+++ b/mixcloud/__init__.py
@@ -34,7 +34,7 @@ class Mixcloud(object):
 
     def me(self):
         url = '{root}/me/'.format(root=self.api_root)
-        r = requests.get(url)
+        r = requests.get(url, {'access_token': self.access_token})
         return User.from_json(r.json(), m=self)
 
     def upload(self, cloudcast, mp3file, picturefile=None):


### PR DESCRIPTION
Hello

The `/me` call requires an access token so that Mixcloud knows who you are. This PR adds that.

Without it Mixcloud responds with:

```
{u'error': {u'message': u'An access_token is required to access this resource.', u'type': u'OAuthException'}}
```
and the `User.from_json` call fails to run.

Cheers
Ben.