### PR TITLE
Oauth helper class

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ Authorization is a multi-step process:
         client_id=client_id, client_secret=client_secret,
         redirect_uri=redirect_uri)
 
-    url = o.authorise_url()
+    url = o.authorize_url()
 
     # Next redirect the user to `url`. They will be redirected to your
     # redirect uri with a `code` query string parameter. This must be

--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,38 @@ Example
     for c in u.cloudcasts():
         print c.name
 
+Authorization
+-------------
+
+You must have an application registered with Mixcloud and a corresponding
+client ID and secret.
+
+Authorization is a multi-step process:
+
+1. Generate the authorization URL
+2. Redirect the user to the URL to authorize your application
+3. Collect the `code` query string parameter from the redirect
+4. Exchange the code for an access token
+
+.. code:: python
+
+    o = mixcloud.MixcloudOauth(
+        client_id=client_id, client_secret=client_secret,
+        redirect_uri=redirect_uri)
+
+    url = o.authorise_url()
+
+    # Next redirect the user to `url`. They will be redirected to your
+    # redirect uri with a `code` query string parameter. This must be
+    # exchanged with Mixcloud for an access token.
+
+    access_token = o.exchange_token(code)
+
+    # This can then be used for calls that required authorization.
+
+    m = mixcloud.Mixcloud(access_token=access_token)
+    print(m.me())
+
 Uploading
 ---------
 
@@ -25,7 +57,7 @@ the constructor.
 
 .. code:: python
 
-    m = mixcloud.Mixcloud(access_token=acces_token)
+    m = mixcloud.Mixcloud(access_token=access_token)
     cc = Cloudcast(...)
     with open(mp3_path) as mp3:
         r = m.upload(cc, mp3)

--- a/mixcloud/__init__.py
+++ b/mixcloud/__init__.py
@@ -5,12 +5,11 @@ import requests
 import unidecode
 import yaml
 
-# Workaround to support both python 2 & 3
 try:
-    import urllib.request, urllib.error
-    import urllib.parse as urllibparse
+    from urllib import urlencode
 except ImportError:
-    import urllib as urllibparse
+    # Python 2 fallback.
+    from urllib.parse import urlencode
 
 
 API_ROOT = 'https://api.mixcloud.com'
@@ -50,7 +49,7 @@ class MixcloudOauth(object):
             'client_id': self.client_id,
             'redirect_uri': self.redirect_uri,
         }
-        return "{}?{}".format(auth_url, urllibparse.urlencode(params))
+        return "{}?{}".format(auth_url, urlencode(params))
 
     def exchange_token(self, code):
         """

--- a/mixcloud/__init__.py
+++ b/mixcloud/__init__.py
@@ -5,6 +5,21 @@ import requests
 import unidecode
 import yaml
 
+# Workaround to support both python 2 & 3
+try:
+    import urllib.request, urllib.error
+    import urllib.parse as urllibparse
+except ImportError:
+    import urllib as urllibparse
+
+
+API_ROOT = 'https://api.mixcloud.com'
+OAUTH_ROOT = 'https://www.mixcloud.com/oauth'
+
+
+class MixcloudOauthError(Exception):
+    pass
+
 
 def setup_yaml():
     def construct_yaml_str(self, node):
@@ -16,9 +31,47 @@ def setup_yaml():
     yaml.SafeLoader.add_constructor(tag, construct_yaml_str)
 
 
+class MixcloudOauth(object):
+    """
+    Assists in the OAuth dance with Mixcloud to get an access token.
+    """
+
+    def __init__(self, client_id=None, client_secret=None, redirect_uri=None):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+
+    def authorize_url(self):
+        """
+        Return a URL to redirect the user to for OAuth authentication.
+        """
+        auth_url = OAUTH_ROOT + '/authorize'
+        params = {
+            'client_id': self.client_id,
+            'redirect_uri': self.redirect_uri,
+        }
+        return "{}?{}".format(auth_url, urllibparse.urlencode(params))
+
+    def exchange_token(self, code):
+        """
+        Exchange the authorization code for an access token.
+        """
+        access_token_url = OAUTH_ROOT + '/access_token'
+        params = {
+            'client_id': self.client_id,
+            'client_secret': self.client_secret,
+            'redirect_uri': self.redirect_uri,
+            'code': code,
+        }
+        resp = requests.get(access_token_url, params=params)
+        if not resp.ok:
+            raise MixcloudOauthError("Could not get access token.")
+        return resp.json()['access_token']
+
+
 class Mixcloud(object):
 
-    def __init__(self, api_root='https://api.mixcloud.com', access_token=None):
+    def __init__(self, api_root=API_ROOT, access_token=None):
         self.api_root = api_root
         self.access_token = access_token
 

--- a/mixcloud/mock.py
+++ b/mixcloud/mock.py
@@ -146,6 +146,13 @@ class MockServer:
                                target_url,
                                body=json.dumps(data))
 
+    def oauth_exchange_fail(self):
+        assert httpretty.is_enabled()
+        target_url = '{root}/{endpoint}'.format(root=self.oauth_root,
+                                                endpoint='access_token')
+        print(target_url)
+        httpretty.register_uri(httpretty.GET, target_url, status=500)
+
 
 def parse_multipart(d):
     lines = d.split(b'\n')

--- a/mixcloud/mock.py
+++ b/mixcloud/mock.py
@@ -10,10 +10,13 @@ except ImportError:
 
 class MockServer:
 
-    def __init__(self, api_root=None):
+    def __init__(self, api_root=None, oauth_root=None):
         if api_root is None:
-            api_root = 'https://api.mixcloud.com'
+            api_root = mixcloud.API_ROOT
         self.api_root = api_root
+        if oauth_root is None:
+            oauth_root = mixcloud.OAUTH_ROOT
+        self.oauth_root = oauth_root
 
     def i_am(self, user):
         assert httpretty.is_enabled()
@@ -133,6 +136,15 @@ class MockServer:
             self.register_cloudcast(user, cc)
             return (200, headers, '{}')
         self.handle_upload(mock_upload)
+
+    def oauth_exchange(self):
+        assert httpretty.is_enabled()
+        target_url = '{root}/{endpoint}'.format(root=self.oauth_root,
+                                                endpoint='access_token')
+        data = {"access_token": "my_access_token"}
+        httpretty.register_uri(httpretty.GET,
+                               target_url,
+                               body=json.dumps(data))
 
 
 def parse_multipart(d):

--- a/tests.py
+++ b/tests.py
@@ -2,7 +2,6 @@ import csv
 import datetime
 import dateutil.tz
 import httpretty
-import json
 import mixcloud
 import io
 import unittest
@@ -222,8 +221,13 @@ class TestMixcloud(unittest.TestCase):
         # Check URL without parameters.
         self.assertEqual(
             full_url.split('?')[0], mixcloud.OAUTH_ROOT + '/authorize')
-        # Check query string parameters
+        # Check query string parameters.
         u = urlsplit(full_url)
         params = parse_qs(u.query)
         self.assertEqual(params['client_id'][0], self.client_id)
         self.assertEqual(params['redirect_uri'][0], self.redirect_uri)
+
+    def testOauthExchange(self):
+        self.mc.oauth_exchange()
+        access_token = self.o.exchange_token('my_code')
+        self.assertEqual(access_token, 'my_access_token')

--- a/tests.py
+++ b/tests.py
@@ -231,3 +231,8 @@ class TestMixcloud(unittest.TestCase):
         self.mc.oauth_exchange()
         access_token = self.o.exchange_token('my_code')
         self.assertEqual(access_token, 'my_access_token')
+
+    def testOauthExchangeServerFail(self):
+        self.mc.oauth_exchange_fail()
+        with self.assertRaises(mixcloud.MixcloudOauthError):
+            self.o.exchange_token('my_code')


### PR DESCRIPTION
Hello

I've added an OAuth helper class to assist with getting a code and exchanging that for an access token, as documented [here](https://www.mixcloud.com/developers/#authorization).

```python
import mixcloud

MIXCLOUD_CLIENT_ID = 'qwerty'
MIXCLOUD_CLIENT_SECRET = 'ytrewq'
redirect_uri = 'http://localhost:8080/my-mixcloud-callback'

auth = mixcloud.MixcloudOauth(
    client_id=MIXCLOUD_CLIENT_ID, client_secret=MIXCLOUD_CLIENT_SECRET,
    redirect_uri=redirect_uri)

url = auth.authorize_url()

# Redirect to the user to the url, Mixcloud will redirect them to
# `redirect_uri` and include a `code` parameter in the query string.

access_token = auth.exchange_token(code)
m = mixcloud.Mixcloud(access_token=access_token)
print(m.user('mrben').name)
```

Hope you think this is useful.

I'm more than happy to rework it if you want it done in a different way.

Ben.