### PR TITLE
Support access token stored in netrc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,14 @@ Authorization is a multi-step process:
     m = mixcloud.Mixcloud(access_token=access_token)
     print(m.me())
 
+Optionally you can store an access token in your `.netrc` file and it
+will be used automatically. The machine name must be `mixcloud-api`.
+
+E.g.::
+
+    machine mixcloud-api
+    password my_access_token
+
 Uploading
 ---------
 

--- a/mixcloud/__init__.py
+++ b/mixcloud/__init__.py
@@ -75,10 +75,16 @@ class Mixcloud(object):
     def __init__(self, api_root=API_ROOT, access_token=None):
         self.api_root = api_root
         if access_token is None:
-            # Attempt netrc lookup.
-            netrc_auth = netrc.netrc().authenticators(NETRC_MACHINE)
-            if netrc_auth:
-                access_token = netrc_auth[2]
+            try:
+                # Attempt netrc lookup.
+                netrc_auth = netrc.netrc().authenticators(NETRC_MACHINE)
+                if netrc_auth:
+                    access_token = netrc_auth[2]
+            except netrc.NetrcParseError:
+                # Configuration errors unrelated to the Mixcloud entry will
+                # cause this exception to be thrown, whether or not there is a
+                # Mixcloud entry.
+                pass
         self.access_token = access_token
 
     def artist(self, key):

--- a/mixcloud/__init__.py
+++ b/mixcloud/__init__.py
@@ -1,5 +1,6 @@
 import collections
 import dateutil.parser
+import netrc
 import re
 import requests
 import unidecode
@@ -12,6 +13,7 @@ except ImportError:
     from urllib.parse import urlencode
 
 
+NETRC_MACHINE = 'mixcloud-api'
 API_ROOT = 'https://api.mixcloud.com'
 OAUTH_ROOT = 'https://www.mixcloud.com/oauth'
 
@@ -72,6 +74,11 @@ class Mixcloud(object):
 
     def __init__(self, api_root=API_ROOT, access_token=None):
         self.api_root = api_root
+        if access_token is None:
+            # Attempt netrc lookup.
+            netrc_auth = netrc.netrc().authenticators(NETRC_MACHINE)
+            if netrc_auth:
+                access_token = netrc_auth[2]
         self.access_token = access_token
 
     def artist(self, key):

--- a/mixcloud/mock.py
+++ b/mixcloud/mock.py
@@ -150,7 +150,6 @@ class MockServer:
         assert httpretty.is_enabled()
         target_url = '{root}/{endpoint}'.format(root=self.oauth_root,
                                                 endpoint='access_token')
-        print(target_url)
         httpretty.register_uri(httpretty.GET, target_url, status=500)
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 httpretty
 nose
+mock

--- a/tests.py
+++ b/tests.py
@@ -3,6 +3,7 @@ import datetime
 import dateutil.tz
 import httpretty
 import mixcloud
+import netrc
 import io
 import unittest
 from mixcloud.mock import MockServer, parse_headers, parse_multipart
@@ -10,12 +11,12 @@ from mixcloud.mock import MockServer, parse_headers, parse_multipart
 try:
     from urllib.parse import parse_qs
     from urllib.parse import urlsplit
-    from urllib.parse import urlencode
+    from unittest import mock
 except ImportError:
     # Python 2 fallback.
     from urlparse import parse_qs
     from urlparse import urlsplit
-    from urllib import urlencode
+    import mock
 
 
 def parse_tracklist(s):
@@ -236,3 +237,10 @@ class TestMixcloud(unittest.TestCase):
         self.mc.oauth_exchange_fail()
         with self.assertRaises(mixcloud.MixcloudOauthError):
             self.o.exchange_token('my_code')
+
+    def testNetrc(self):
+        ret_value = ('', None, 'my_access_token')
+        with mock.patch.object(netrc.netrc, 'authenticators',
+                               return_value=ret_value):
+            m = mixcloud.Mixcloud()
+            self.assertEqual(m.access_token, ret_value[2])


### PR DESCRIPTION
Addresses issue #9.

This PR supports reading an access token from the netrc file.

The config machine name is `mixcloud-api` because if you use the actual hostname (`api.mixcloud.com`) as recommended, Requests [will use it](http://docs.python-requests.org/en/v2.0-0/user/authentication/#netrc-authentication) in error and add a basic auth header[0]. Mixcloud ignores this it seems but it doesn't seem like the right thing to be doing.

I opted to ignore any configuration errors in the netrc file since the user might not even be using netrc with Mixcloud.

[0] E.g.:

```python
// (Pdb) x.request.headers
{
	'Accept': '*/*',
	'Connection': 'keep-alive',
	'Accept-Encoding': 'gzip, deflate',
	'Authorization': 'Basic Xm9uXXpXXXXXX2t1aXXqXkx2XXpia1XrXlXXXnpXX1pXXlX3cw==',
	'User-Agent': 'python-requests/2.8.0'
}
```