### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from pip.req import parse_requirements
 import setuptools
 
 with open('README.rst') as f:
@@ -19,6 +18,9 @@ setuptools.setup(name='mixcloud',
                      'requests',
                      'unidecode',
                      'pyyaml',
+                     'httpretty',
+                     'nose',
+                     'mock'
                  ],
                  description='Bindings for the mixcloud.com API',
                  long_description=readme + '\n\n' + history,


### PR DESCRIPTION
When attempting to install the mixcloud library using pip 10.0+, the following error occurs:

```sh
➜ pip install mixcloud
Collecting mixcloud
  Using cached https://files.pythonhosted.org/packages/e3/9e/70aedb77e9b5d99b54dd569d0ba2357cb64909b20805f459f90d45c426c6/mixcloud-0.4.0.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-v5rwvzwv/mixcloud/setup.py", line 1, in <module>
        from pip.req import parse_requirements
    ModuleNotFoundError: No module named 'pip.req'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-install-v5rwvzwv/mixcloud/
```

Since pip 10.0, pip.reqs is no longer included and requirements are now preferred to be inside of the install_requires kwarg inside of the setuptools.setup(). I have moved the contents of requirements_dev.txt to this kwarg and removed the line importing pip.reqs.